### PR TITLE
fix: upgrade social-auth-core and social-auth-app-django + fix GitHub login POST requirement

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -10,6 +10,6 @@ drf-nested-routers==0.95.0
 drf-yasg==1.21.15
 geoip2==5.2.0
 requests==2.34.2
-social-auth-core==4.9.1
-social-auth-app-django==5.9.0
+social-auth-core==5.0.2
+social-auth-app-django==6.0.0
 setuptools==82.0.1

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -28,7 +28,7 @@
     <p><a href="{% url 'password_reset' %}">Lost password?</a></p>
     <p><a href="{% url 'register' %}">Register</a></p>
 
-    <form method="post" action="{% url "social:begin" "github" %}" class="d-inline">
+    <form method="post" action="{% url 'social:begin' 'github' %}" class="d-inline">
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ next }}">
         <button type="submit" class="btn btn-link p-0">Login with GitHub</button>

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -28,5 +28,9 @@
     <p><a href="{% url 'password_reset' %}">Lost password?</a></p>
     <p><a href="{% url 'register' %}">Register</a></p>
 
-    <a href="{% url "social:begin" "github" %}">Login with GitHub</a>
+    <form method="post" action="{% url "social:begin" "github" %}" class="d-inline">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ next }}">
+        <button type="submit" class="btn btn-link p-0">Login with GitHub</button>
+    </form>
 {% endblock %}


### PR DESCRIPTION
This PR resolves the CI failures from Dependabot PRs #387 and #389.

## Changes
- Bumped `social-auth-core` from 4.9.1 to 5.0.2
- Bumped `social-auth-app-django` from 5.9.0 to 6.0.0

These packages were updated together because `social-auth-app-django` 6.0+ requires `social-auth-core` >= 5.0 (separate bumps caused dependency resolution errors in CI).

## Login flow fix
Changed the "Login with GitHub" link from a plain `<a href>` (GET request) to a proper `<form method="post">` in [templates/registration/login.html](templates/registration/login.html).

Starting with social-auth-app-django 6.0, login initiation views require POST requests (the `SOCIAL_AUTH_REQUIRE_POST` setting was removed in this major version).

## Why this matters
- Fixes `pip install` failures during "Install Dependencies" step in Django CI
- Prevents 405 Method Not Allowed errors when clicking GitHub login

Co-authored-by: Grok <grok@x.ai>